### PR TITLE
fix missing annotation when not filtered for specific fields

### DIFF
--- a/cmd/testdata/case-9-collector-errors-json.golden
+++ b/cmd/testdata/case-9-collector-errors-json.golden
@@ -2,6 +2,7 @@
     "caller": "github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/exporterkit/collector/set.go:92",
     "level": "error",
     "message": "failed collecting metrics",
+    "annotation": "awsclusters.infrastructure.giantswarm.io "k55y7" not found",
     "stack": [
         { "file": "/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/exporterkit/collector/set.go", "line": 92 },
         { "file": "/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/exporterkit/collector/set.go", "line": 83 },

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -197,21 +197,29 @@ func colour(l string, output string, colourFunc func(v ...interface{}) string, i
 						for j, v := range list {
 							_, ok := v["line"]
 							if !ok {
-								annotation = v["file"].(string) + ", " + annotation
+								if annotation == "" {
+									annotation = v["file"].(string)
+								} else {
+									annotation = v["file"].(string) + ", " + annotation
+								}
 								list = append(list[:j], list[j+1:]...)
 								continue
 							}
 						}
 
+						var withAnn bool
 						var expressions []*regexp.Regexp
 						for _, f := range fields {
 							expressions = append(expressions, regexp.MustCompile(f))
 						}
-
 						for _, e := range expressions {
 							if e.MatchString("annotation") {
-								s += indent + colorKey("\"annotation\"") + ": " + colourFunc("\""+annotation+"\"") + ",\n"
+								withAnn = true
 							}
+						}
+
+						if withAnn || len(fields) == 0 {
+							s += indent + colorKey("\"annotation\"") + ": " + colourFunc("\""+annotation+"\"") + ",\n"
 						}
 					}
 				}


### PR DESCRIPTION
The annotation was missing when parsing legacy error stacks. It was printed when explicitly selected though. Fixing this. The order is not properly managed with legacy error stacks but considering this is a temporary problem I do not care about this now. 